### PR TITLE
pr: v.1.1.0 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,4 +92,15 @@
   `docker-compose -f docker-compose-local.yml up`
 
 
-  
+  --- 
+
+## v.1.1.0 update note
+
+- 카프카를 이용한 비동기 메시지 큐 구현
+  - 의존성 구성 방식: `Docker-compose` 실행시 컨테이너에 `Kafka`와 `Zookeeper`를 함께 생성, `configure` 클래스에서 `bean` 등록
+  - 작동 방식:
+    - 새로운 `Voc`가 생성되면 `KafkaProducerService`의 `notifyNewVoc()`를 통해 등록 메시지가 `message queue`로 전달된다. `KafkaConsumerService`의 `handleNewVocNotification()` 메서드는 `new-voc` 토픽을 구독하여 새로운 `Voc` 정보를 받아본다.
+    - 기존 notification alert 방식인 Sse Emitter는 유지하며, 기존 코드의 큰 수정 삭제 없이 kafka 아키텍처를 구성
+  - 의의: 
+    - 현재 코드에서는 단순히 업데이트에 대한 `notification` 용도로 유의미한 데이터를 전달하지는 않는다.
+    - 추후 `app push` 기능을 추가할 수 있는 구성적 기반 마련한다.

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // kafka
+    implementation 'org.springframework.kafka:spring-kafka'
 
     // thymeleaf
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -13,3 +13,25 @@ services:
       - ./database/config:/etc/mysql/conf.d
     ports:
       - "3300:3306"
+  timf-voc-task-kafka:
+    container_name: timf-voc-task-kafka
+    image: confluentinc/cp-kafka:6.1.0
+    hostname: kafka
+    environment:
+      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2182
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9093
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+    ports:
+      - "9093:9093"
+    depends_on:
+      - timf-voc-task-zookeeper
+  timf-voc-task-zookeeper:
+    container_name: timf-voc-task-zookeeper
+    hostname: zookeeper
+    image: confluentinc/cp-zookeeper:6.1.0
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2182
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "2182:2182"
+

--- a/src/main/java/timf/voc/task/config/messagequeue/KafkaConsumerConfig.java
+++ b/src/main/java/timf/voc/task/config/messagequeue/KafkaConsumerConfig.java
@@ -1,0 +1,48 @@
+package timf.voc.task.config.messagequeue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+@Configuration
+@EnableKafka
+public class KafkaConsumerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Value("${spring.kafka.consumer.group-id}")
+    private String consumerGroupId;
+
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ConsumerConfig.GROUP_ID_CONFIG, consumerGroupId);
+        configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        return new DefaultKafkaConsumerFactory<>(configProps);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
+        ConsumerFactory<String, String> consumerFactory) {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory);
+        return factory;
+    }
+}
+

--- a/src/main/java/timf/voc/task/config/messagequeue/KafkaProducerConfig.java
+++ b/src/main/java/timf/voc/task/config/messagequeue/KafkaProducerConfig.java
@@ -1,0 +1,37 @@
+package timf.voc.task.config.messagequeue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+@Configuration
+@EnableKafka
+public class KafkaProducerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate(ProducerFactory<String, String> producerFactory) {
+        return new KafkaTemplate<>(producerFactory);
+    }
+}
+

--- a/src/main/java/timf/voc/task/service/KafkaConsumerService.java
+++ b/src/main/java/timf/voc/task/service/KafkaConsumerService.java
@@ -1,0 +1,17 @@
+package timf.voc.task.service;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class KafkaConsumerService {
+
+    @KafkaListener(topics = "new-voc")
+    public void handleNewVocNotification(String message) {
+        log.info("Received Kafka message: " + message);
+        // todo : invoke app push alert
+    }
+}

--- a/src/main/java/timf/voc/task/service/KafkaProducerService.java
+++ b/src/main/java/timf/voc/task/service/KafkaProducerService.java
@@ -1,0 +1,17 @@
+package timf.voc.task.service;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class KafkaProducerService {
+
+	private final KafkaTemplate<String, String> kafkaTemplate;
+
+	public void notifyNewVoc() {
+		kafkaTemplate.send("new-voc", "vocCreated");
+	}
+}

--- a/src/main/java/timf/voc/task/service/NotificationService.java
+++ b/src/main/java/timf/voc/task/service/NotificationService.java
@@ -38,7 +38,7 @@ public class NotificationService {
         return emitter;
     }
 
-    public void notifyVocUpdate() {
+    public void notifyNewVoc() {
         List<String> deadEmitters = new ArrayList<>();
         emittersMap.forEach((key, emitter) -> {
             try {

--- a/src/main/java/timf/voc/task/service/VocService.java
+++ b/src/main/java/timf/voc/task/service/VocService.java
@@ -28,6 +28,7 @@ public class VocService {
 	private final TransportCompanyService transportCompanyService;
 	private final ClaimService claimService;
 	private final NotificationService notificationService;
+	private final KafkaProducerService kafkaProducerService;
 
 	private final VocRepository vocRepository;
 	private final CompensationRepository compensationRepository;
@@ -44,7 +45,9 @@ public class VocService {
 		 */
 		claimService.handleStatus(vocRequest, true);
 
-		notificationService.notifyVocUpdate();
+		notificationService.notifyNewVoc();
+		kafkaProducerService.notifyNewVoc();
+
 	}
 
 	public List<VocResponse> getVocs() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,9 @@ spring:
     active: local
 
 ---
+server:
+  port: 54380
+
 spring:
   config:
     activate:
@@ -21,6 +24,12 @@ spring:
 
     generate-ddl: true
 
+  kafka:
+    bootstrap-servers: localhost:9093
+    consumer:
+      group-id: voc-notification
+
   sql:
     init:
       mode: always
+

--- a/src/test/java/timf/voc/task/service/NotificationServiceTest.java
+++ b/src/test/java/timf/voc/task/service/NotificationServiceTest.java
@@ -54,7 +54,7 @@ class NotificationServiceTest {
 			})));
 
 		// when
-		notificationService.notifyVocUpdate();
+		notificationService.notifyNewVoc();
 
 		// then
 		// Verify the interactions with the emitters directly

--- a/src/test/java/timf/voc/task/service/VocServiceTest.java
+++ b/src/test/java/timf/voc/task/service/VocServiceTest.java
@@ -71,7 +71,7 @@ class VocServiceTest {
 			.thenReturn(clientCompany);
 
 		willDoNothing().given(claimService).handleStatus(vocRequest, true);
-		willDoNothing().given(notificationService).notifyVocUpdate();
+		willDoNothing().given(notificationService).notifyNewVoc();
 
 		// when
 		vocService.registerVoc(vocRequest);


### PR DESCRIPTION
pr: v.1.1.0 update

update note

- 카프카를 이용한 비동기 메시지 큐 구현
  - 의존성 구성 방식: `Docker-compose` 실행시 컨테이너에 `Kafka`와 `Zookeeper`를 함께 생성, `configure` 클래스에서 `bean` 등록
  - 작동 방식:
    - 새로운 `Voc`가 생성되면 `KafkaProducerService`의 `notifyNewVoc()`를 통해 등록 메시지가 `message queue`로 전달된다. `KafkaConsumerService`의 `handleNewVocNotification()` 메서드는 `new-voc` 토픽을 구독하여 새로운 `Voc` 정보를 받아본다.
    - 기존 notification alert 방식인 Sse Emitter는 유지하며, 기존 코드의 큰 수정 삭제 없이 kafka 아키텍처를 구성
  - 의의: 
    - 현재 코드에서는 단순히 업데이트에 대한 `notification` 용도로 유의미한 데이터를 전달하지는 않는다.
    - 추후 `app push` 기능을 추가할 수 있는 구성적 기반 마련한다.
